### PR TITLE
Fix /user/ API to load profile for current user

### DIFF
--- a/core/common/management/commands/setup_superuser.py
+++ b/core/common/management/commands/setup_superuser.py
@@ -10,6 +10,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         user = UserProfile.objects.get(username='ocladmin', is_superuser=True)
         user.set_password(settings.API_SUPERUSER_PASSWORD)
+        user.save()
         user.set_token(settings.API_SUPERUSER_TOKEN)
         user.save()
 

--- a/core/users/user_urls.py
+++ b/core/users/user_urls.py
@@ -9,7 +9,7 @@ extra_kwargs = dict(user_is_self=True)
 # shortcuts for the currently logged-in user
 urlpatterns = [
     re_path(
-        r'^$', views.UserDetailView.as_view(), name='user-self-detail'
+        r'^$', views.UserDetailView.as_view(), extra_kwargs, name='user-self-detail'
     ),
     re_path(
         r'^orgs/$', orgs_views.OrganizationListView.as_view(), extra_kwargs, name='user-organization-list'


### PR DESCRIPTION
Also fixes the association between the ocladmin profile and the token so the `/user/` URL works for ocladmin as well.