### PR TITLE
chore: make scheme configurable for elastic search connection

### DIFF
--- a/core/common/utils.py
+++ b/core/common/utils.py
@@ -418,14 +418,14 @@ def es_get(url, **kwargs):
         for es_host in settings.ES_HOSTS.split(','):
             try:
                 return requests.get(
-                    f'http://{es_host}/{url}',
+                    f'{settings.ES_SCHEME}://{es_host}/{url}',
                     **kwargs
                 )
             except ConnectTimeout:
                 continue
     else:
         return requests.get(
-            f'http://{settings.ES_HOST}:{settings.ES_PORT}/{url}',
+            f'{settings.ES_SCHEME}://{settings.ES_HOST}:{settings.ES_PORT}/{url}',
             **kwargs
         )
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -194,6 +194,7 @@ DATABASES = {
 ES_HOST = os.environ.get('ES_HOST', 'es')  # Deprecated. Use ES_HOSTS instead.
 ES_PORT = os.environ.get('ES_PORT', '9200')  # Deprecated. Use ES_HOSTS instead.
 ES_HOSTS = os.environ.get('ES_HOSTS', None)
+ES_SCHEME = os.environ.get('ES_SCHEME', 'http')
 ELASTICSEARCH_DSL = {
     'default': {
         'hosts': ES_HOSTS.split(',') if ES_HOSTS else [ES_HOST + ':' + ES_PORT]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -31,6 +31,7 @@ services:
       - DB_PORT=${DB_PORT-5432}
       - DB_PASSWORD=${DB_PASSWORD-Postgres123}
       - ES_HOSTS=${ES_HOSTS-es:9200}
+      - ES_SCHEME=${ES_SCHEME-http}
       - ENVIRONMENT=production
       - DEBUG=${DEBUG-FALSE}
       - SECRET_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - DB_PORT=${DB_PORT-5432}
       - DB_PASSWORD=${DB_PASSWORD-Postgres123}
       - ES_HOSTS=${ES_HOSTS-es:9200}
+      - ES_SCHEME=${ES_SCHEME-http}
       - ENVIRONMENT=${ENVIRONMENT-production}
       - DEBUG=${DEBUG-FALSE}
       - SECRET_KEY


### PR DESCRIPTION
This PR introduces enhancements to the `es_get` function, allowing the scheme used for connecting to the Elasticsearch cluster to be configurable. This is done to address the error `Client sent an HTTP request to an HTTPS server` when passing `http` in the host while using Elasticsearch on elastic cloud (https://www.elastic.co/cloud/)