### PR TITLE
Switch response body to OperationOutcome for empty queryset in $lookup

### DIFF
--- a/core/code_systems/views.py
+++ b/core/code_systems/views.py
@@ -49,25 +49,25 @@ class CodeSystemListView(SourceListView):
 
 
 class CodeSystemLookupNotFoundError(ValidationError):
-    def __init__(self):
-        super().__init__(detail=
-            {
+    def __init__(self, code: str = None):
+        message = f"Code '{code}' not found" if code else "Code not found"
+        super().__init__(
+            detail={
                 "resourceType": "OperationOutcome",
                 "id": "exception",
                 "text": {
                     "status": "additional",
-                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Code not found</div>"
+                    "div": f'<div xmlns="http://www.w3.org/1999/xhtml">{message}</div>',
                 },
                 "issue": [
                     {
                         "severity": "error",
                         "code": "not-found",
-                        "details": {
-                            "text": "Code not found"
-                        }
+                        "details": {"text": message},
                     }
-                ]
-            })
+                ],
+            }
+        )
 
 
 class CodeSystemListLookupView(ConceptRetrieveUpdateDestroyView):
@@ -94,6 +94,8 @@ class CodeSystemListLookupView(ConceptRetrieveUpdateDestroyView):
 
                 if source:
                     queryset = queryset.filter(sources=source.first(), mnemonic=code)
+                    if not queryset.exists():
+                        raise CodeSystemLookupNotFoundError(code)
                     return queryset
 
         raise CodeSystemLookupNotFoundError()


### PR DESCRIPTION
Noticed that when an empty queryset is returned in a `$lookup` operation the response body is DRF's default `404` response instead of an `OperationOutcome` as documented in the [$lookup docs](https://www.hl7.org/fhir/codesystem-operation-lookup.html)