### PR TITLE
Create license-header.txt

### DIFF
--- a/license-header.txt
+++ b/license-header.txt
@@ -1,0 +1,6 @@
+This Source Code is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at
+http://mozilla.org/MPL/2.0/. Open Concept Lab is also distributed under the
+terms of the Healthcare Disclaimer located at https://openconceptlab.org/license/.
+
+Copyright (C) Open Concept Lab.


### PR DESCRIPTION
Created license-header.txt. Per convention, this is to be added as a header to all source code files in the repo