### PR TITLE
Improve development environment defaults and storage setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,100 @@
+# =============================================================================
+# OCL API2 - Environment Variables
+# Copy this file to .env and adjust the values for your environment.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# General
+# -----------------------------------------------------------------------------
+ENVIRONMENT=development
+DEBUG=TRUE
+# Disables the lookup of language maps on startup (speeds up dev boot)
+NO_LM=TRUE
+SERVICE_NAME=oclapi2
+
+# -----------------------------------------------------------------------------
+# API
+# -----------------------------------------------------------------------------
+API_BASE_URL=http://localhost:8000
+API_INTERNAL_BASE_URL=http://api:8000
+API_HOST=0.0.0.0
+API_PORT=8000
+API_SUPERUSER_PASSWORD=Root123
+API_SUPERUSER_TOKEN=891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6
+SECRET_KEY=
+
+# -----------------------------------------------------------------------------
+# Database (PostgreSQL)
+# -----------------------------------------------------------------------------
+DB=postgres
+DB_HOST=db
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=Postgres123
+
+# -----------------------------------------------------------------------------
+# Redis
+# -----------------------------------------------------------------------------
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# -----------------------------------------------------------------------------
+# Elasticsearch
+# -----------------------------------------------------------------------------
+ES_HOSTS=es:9200
+ES_SCHEME=http
+
+# -----------------------------------------------------------------------------
+# Export Storage
+# Supported backends:
+#   core.services.storages.cloud.aws.S3        (AWS S3)
+#   core.services.storages.cloud.minio.MinIO   (MinIO or any S3-compatible, e.g. RustFS)
+#   core.services.storages.cloud.azure.BlobStorage
+# -----------------------------------------------------------------------------
+EXPORT_SERVICE=core.services.storages.cloud.minio.MinIO
+
+# MinIO / RustFS (S3-compatible) — used when EXPORT_SERVICE=MinIO
+MINIO_ENDPOINT=rustfs:9000
+MINIO_ACCESS_KEY=rustfsadmin
+MINIO_SECRET_KEY=rustfsadmin
+MINIO_BUCKET_NAME=oclapi2-dev
+MINIO_SECURE=false
+
+# AWS S3 — used when EXPORT_SERVICE=S3
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_STORAGE_BUCKET_NAME=oclapi2-dev
+AWS_REGION_NAME=us-east-2
+
+# Azure Blob Storage — used when EXPORT_SERVICE=BlobStorage
+AZURE_STORAGE_ACCOUNT_NAME=
+AZURE_STORAGE_CONTAINER_NAME=
+AZURE_STORAGE_CONNECTION_STRING=
+
+# -----------------------------------------------------------------------------
+# Flower (Celery monitoring UI)
+# -----------------------------------------------------------------------------
+FLOWER_USER=root
+FLOWER_PASSWORD=Root123
+
+# -----------------------------------------------------------------------------
+# FHIR Validator
+# -----------------------------------------------------------------------------
+FHIR_VALIDATOR_URL=http://fhir_validator:3500
+
+# -----------------------------------------------------------------------------
+# Error tracking (optional)
+# -----------------------------------------------------------------------------
+SENTRY_DSN_KEY=
+ERRBIT_URL=
+ERRBIT_KEY=
+
+# -----------------------------------------------------------------------------
+# Email (optional)
+# -----------------------------------------------------------------------------
+EMAIL_NOREPLY_PASSWORD=
+
+# -----------------------------------------------------------------------------
+# Throttling (optional)
+# -----------------------------------------------------------------------------
+ENABLE_THROTTLING=

--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,9 @@ ES_SCHEME=http
 EXPORT_SERVICE=core.services.storages.cloud.minio.MinIO
 
 # MinIO / RustFS (S3-compatible) — used when EXPORT_SERVICE=MinIO
+MINIO_PORT=9090
 MINIO_ENDPOINT=rustfs:9000
+MINIO_EXTERNAL_ENDPOINT=localhost:${MINIO_PORT:-9090}
 MINIO_ACCESS_KEY=rustfsadmin
 MINIO_SECRET_KEY=rustfsadmin
 MINIO_BUCKET_NAME=oclapi2-dev

--- a/.gitignore
+++ b/.gitignore
@@ -257,6 +257,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+docker-compose.override.yml
 
 # Spyder project settings
 .spyderproject

--- a/core/services/storages/cloud/minio.py
+++ b/core/services/storages/cloud/minio.py
@@ -21,10 +21,12 @@ class MinIO(CloudStorageServiceInterface):
         self.secure = settings.MINIO_SECURE
         self.client = Minio(endpoint=self.endpoint, access_key=self.access_key, secret_key=self.secret_key,
                             secure=self.secure)
-        # Separate client for presigned URL generation using the externally accessible endpoint.
+        # Dedicated client for presigned URL generation.
+        # Uses the external endpoint so the signature carries the publicly accessible host.
         # Region is set explicitly to avoid a network round-trip for region discovery
         # (the external endpoint is not reachable from inside the container).
-        self.external_client = Minio(
+        # All other operations use self.client (internal endpoint) since they run server-side.
+        self._presign_client = Minio(
             endpoint=self.external_endpoint, access_key=self.access_key, secret_key=self.secret_key,
             secure=self.secure, region=settings.MINIO_REGION
         ) if self.external_endpoint != self.endpoint else self.client
@@ -90,7 +92,7 @@ class MinIO(CloudStorageServiceInterface):
         Falls back to the internal client when no external endpoint is configured.
         """
         try:
-            return self.external_client.get_presigned_url(
+            return self._presign_client.get_presigned_url(
                 method='GET', bucket_name=self.bucket_name, object_name=file_path
             ) if file_path else None
         except S3Error as e:

--- a/core/services/storages/cloud/minio.py
+++ b/core/services/storages/cloud/minio.py
@@ -14,12 +14,20 @@ class MinIO(CloudStorageServiceInterface):
     def __init__(self):
         super().__init__()
         self.endpoint = settings.MINIO_ENDPOINT
+        self.external_endpoint = settings.MINIO_EXTERNAL_ENDPOINT or self.endpoint
         self.access_key = settings.MINIO_ACCESS_KEY
         self.secret_key = settings.MINIO_SECRET_KEY
         self.bucket_name = settings.MINIO_BUCKET_NAME
         self.secure = settings.MINIO_SECURE
         self.client = Minio(endpoint=self.endpoint, access_key=self.access_key, secret_key=self.secret_key,
                             secure=self.secure)
+        # Separate client for presigned URL generation using the externally accessible endpoint.
+        # Region is set explicitly to avoid a network round-trip for region discovery
+        # (the external endpoint is not reachable from inside the container).
+        self.external_client = Minio(
+            endpoint=self.external_endpoint, access_key=self.access_key, secret_key=self.secret_key,
+            secure=self.secure, region=settings.MINIO_REGION
+        ) if self.external_endpoint != self.endpoint else self.client
         # Ensure the bucket exists
         if not self.client.bucket_exists(self.bucket_name):
             self.client.make_bucket(self.bucket_name)
@@ -77,11 +85,14 @@ class MinIO(CloudStorageServiceInterface):
 
     def url_for(self, file_path):
         """
-        Generates a presigned URL for the given file.
+        Generates a presigned URL for the given file using the external client so the
+        signature is computed with the publicly accessible host (MINIO_EXTERNAL_ENDPOINT).
+        Falls back to the internal client when no external endpoint is configured.
         """
         try:
-            return self.client.get_presigned_url(method='GET', bucket_name=self.bucket_name, object_name=file_path) \
-                if file_path else None
+            return self.external_client.get_presigned_url(
+                method='GET', bucket_name=self.bucket_name, object_name=file_path
+            ) if file_path else None
         except S3Error as e:
             raise Exception(f"Could not generate presigned URL for file {file_path}. Error: {e}") from e  # pylint: disable=broad-exception-raised
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -609,6 +609,8 @@ if ENV == 'development':
 
 # MINIO storage settings
 MINIO_ENDPOINT = os.environ.get('MINIO_ENDPOINT', '')
+MINIO_EXTERNAL_ENDPOINT = os.environ.get('MINIO_EXTERNAL_ENDPOINT', '')
+MINIO_REGION = os.environ.get('MINIO_REGION', 'us-east-1')
 MINIO_ACCESS_KEY = os.environ.get('MINIO_ACCESS_KEY', '')
 MINIO_SECRET_KEY = os.environ.get('MINIO_SECRET_KEY', '')
 MINIO_BUCKET_NAME = os.environ.get('MINIO_BUCKET_NAME', '')

--- a/docker-compose.override.yml.bak
+++ b/docker-compose.override.yml.bak
@@ -1,12 +1,25 @@
 services:
+  rustfs:
+    image: rustfs/rustfs
+    ports:
+      - 9000:9000
+      - 9001:9001
+    environment:
+      - RUSTFS_ROOT_USER=${MINIO_ACCESS_KEY-rustfsadmin}
+      - RUSTFS_ROOT_PASSWORD=${MINIO_SECRET_KEY-rustfsadmin}
+    volumes:
+      - rustfs-data:/data
+    restart: "no"
   db:
     ports:
       - 5432:5432
     restart: "no"
+    command: postgres -c max_connections=300
   redis:
     ports:
       - 6379:6379
     restart: "no"
+    command: /opt/bitnami/scripts/redis/run.sh --maxmemory 4096mb
   api:
     build: .
     ports:
@@ -20,9 +33,17 @@ services:
       - es
       - celery
       - flower
+      - rustfs
     environment:
       - ENVIRONMENT=development
       - DEBUG=${DEBUG-TRUE}
+      - NO_LM=TRUE
+      - EXPORT_SERVICE=core.services.storages.cloud.minio.MinIO
+      - MINIO_ENDPOINT=rustfs:9000
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY-rustfsadmin}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY-rustfsadmin}
+      - MINIO_BUCKET_NAME=${MINIO_BUCKET_NAME-oclapi2-dev}
+      - MINIO_SECURE=${MINIO_SECURE-false}
   celery:
     build: .
     volumes:
@@ -93,3 +114,8 @@ services:
     ports:
       - 9200:9200
     restart: "no"
+    environment:
+      - m=4gb
+
+volumes:
+  rustfs-data:

--- a/docker-compose.override.yml.bak
+++ b/docker-compose.override.yml.bak
@@ -2,7 +2,7 @@ services:
   rustfs:
     image: rustfs/rustfs
     ports:
-      - 9000:9000
+      - ${MINIO_PORT:-9000}:9000
       - 9001:9001
     environment:
       - RUSTFS_ROOT_USER=${MINIO_ACCESS_KEY-rustfsadmin}
@@ -40,6 +40,7 @@ services:
       - NO_LM=TRUE
       - EXPORT_SERVICE=core.services.storages.cloud.minio.MinIO
       - MINIO_ENDPOINT=rustfs:9000
+      - MINIO_EXTERNAL_ENDPOINT=${MINIO_EXTERNAL_ENDPOINT-localhost:${MINIO_PORT:-9000}}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY-rustfsadmin}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY-rustfsadmin}
       - MINIO_BUCKET_NAME=${MINIO_BUCKET_NAME-oclapi2-dev}


### PR DESCRIPTION
## Summary

This PR improves the local development environment by documenting the expected defaults, reducing maintenance overhead from deprecated components, and making the storage layer more practical for development and testing workflows.

## Context

The current development setup had a few limitations:

- MinIO is now obsolete in this project context and will no longer be maintained
- the development override file should not be treated as a documented default entrypoint, since it is an override-only file meant for local use
- using an AWS S3 bucket in development prevents some features from being tested properly or consistently
- a more efficient local storage service was needed to replace the previous approach

To address this, the development environment now moves toward a documented default `.env` template and a backup-based override workflow, while introducing `RUSTFS` as the preferred local S3-compatible service.

## What changed

- added `.env.example` documenting the expected development defaults for:
  - core services
  - storage configuration
  - optional integrations

- renamed `docker-compose.override.yml` to `docker-compose.override.yml.bak`

- updated the repository to ignore the active override file, so local developer-specific overrides are not committed accidentally

- preserved the backup override template so developers can still enable it locally when needed with:

~~~sh
cp docker-compose.override.yml.bak docker-compose.override.yml
~~~

- kept the expanded storage-related development setup available in the backup override file

- introduced `RUSTFS` as the local storage service, replacing the previous dependence on MinIO for active development workflows

## Why this approach

This approach keeps the repository cleaner and makes the development workflow more explicit:

- documented defaults live in `.env.example`
- local override behavior remains available, but is treated as local-only customization
- deprecated infrastructure is no longer presented as the default path
- local storage testing becomes more realistic and less constrained than using AWS S3 directly during development

## Benefits

- clearer onboarding for development environments
- less confusion around which files are documented defaults versus local overrides
- fewer accidental commits of machine-specific override changes
- better support for testing storage-dependent features locally
- improved maintainability by moving away from MinIO
- more efficient local S3-compatible behavior through `RUSTFS`

## Notes for reviewers

Developers who need local override behavior can still enable it manually:

~~~sh
cp docker-compose.override.yml.bak docker-compose.override.yml
~~~

This preserves flexibility for development without keeping override configuration as a first-class tracked file.