### PR TITLE
OpenConceptLab/ocl_issues#2476 | fix slow mapped-sources endpoint

### DIFF
--- a/core/sources/models.py
+++ b/core/sources/models.py
@@ -679,8 +679,12 @@ class Source(DirtyFieldsMixin, ConceptContainerModel):
         return self.get_max_mapping_attribute('updated_at')
 
     def get_mapped_sources(self, exclude_self=True):
-        """Returns only direct mapped sources"""
-        queryset = Source.objects.filter(mappings_to__sources=self).distinct()
+        mapped_source_ids = (
+            self.get_mappings_queryset()
+            .values_list('to_source_id', flat=True)
+            .distinct()
+        )
+        queryset = Source.objects.filter(id__in=mapped_source_ids)
         if exclude_self:
             queryset = queryset.exclude(id=self.id)
         return queryset

--- a/core/sources/models.py
+++ b/core/sources/models.py
@@ -680,13 +680,10 @@ class Source(DirtyFieldsMixin, ConceptContainerModel):
 
     def get_mapped_sources(self, exclude_self=True):
         """Returns only direct mapped sources"""
-        source_ids = self.__get_mapped_source_ids()
+        queryset = Source.objects.filter(mappings_to__sources=self).distinct()
         if exclude_self:
-            source_ids = set(source_ids) - {self.id}
-        return Source.objects.filter(id__in=source_ids)
-
-    def __get_mapped_source_ids(self):
-        return self.mappings.values_list('to_source_id', flat=True)
+            queryset = queryset.exclude(id=self.id)
+        return queryset
 
     def clone_resources(self, user, concepts, mappings, **kwargs):
         from core.mappings.models import Mapping


### PR DESCRIPTION
## Summary
- `Source.get_mapped_sources` rewritten as a direct `DISTINCT` join over the `to_source` FK instead of an `id__in` subquery across the mappings M2M.
- Fixes ~38s response times on `GET /orgs/CIEL/sources/CIEL/latest/mapped-sources/`.

## Why it was slow
The old implementation:

```python
source_ids = self.mappings.values_list('to_source_id', flat=True)  # M2M, no DISTINCT
return Source.objects.filter(id__in=source_ids)
```

For CIEL latest, `self.mappings` yields one row per mapping in the version (hundreds of thousands). Postgres can't collapse the subquery early, and DRF pagination runs it twice (COUNT + page). True result set is only a few dozen sources.

The new form lets Postgres use the `mappings_mapping.to_source_id` index directly and return in sub-second time.

## Test plan
- [ ] `GET /orgs/CIEL/sources/CIEL/latest/mapped-sources/?brief=true&limit=25` returns the same set as before, in < 1s
- [ ] `excludeSelf=false` still includes CIEL itself when present
- [ ] Existing `test_get_mapped_sources` unit tests pass

closes OpenConceptLab/ocl_issues#2476