### PR TITLE
Track signup and logout in analytics middleware

### DIFF
--- a/core/middlewares/middlewares.py
+++ b/core/middlewares/middlewares.py
@@ -275,11 +275,13 @@ class AnalyticsMiddleware(BaseMiddleware):
         response = self.get_response(request)
         path = request.path
 
-        ignore_any_under_paths = ['/users/logout/', '/users/signup/']
+        # /users/signup/ and /users/logout/ are tracked — they're real
+        # user-intent events (top-of-funnel + session-end signal). Login
+        # tracking was added previously via ocl_online#55.
+        ignore_any_under_paths = []
         ignore_paths = [
             '', '/swagger', '/redoc', '/version', '/toggles', '/users/oidc/code-exchange', '/favicon.ico',
             '/users/api-token', '/users/password/reset', '/user',
-            *[p.rstrip('/') for p in ignore_any_under_paths]
         ]
         if path.rstrip("/") not in ignore_paths and not any(path.startswith(p) for p in ignore_any_under_paths):
             duration_ms = int((time.monotonic() - start) * 1000)


### PR DESCRIPTION
## Summary

Removes `/users/signup/` and `/users/logout/` from `AnalyticsMiddleware`'s ignore-list. They're real user-intent events — top-of-funnel and session-end — and belong in `APITransaction` alongside the login events already tracked via [ocl_online#55 / PR #843](https://github.com/OpenConceptLab/oclapi2/pull/843).

Closes OpenConceptLab/ocl_online#70.

## Changes

```diff
-        ignore_any_under_paths = ['/users/logout/', '/users/signup/']
+        # /users/signup/ and /users/logout/ are tracked — they're real
+        # user-intent events (top-of-funnel + session-end signal). Login
+        # tracking was added previously via ocl_online#55.
+        ignore_any_under_paths = []
         ignore_paths = [
             '', '/swagger', '/redoc', '/version', '/toggles', '/users/oidc/code-exchange', '/favicon.ico',
             '/users/api-token', '/users/password/reset', '/user',
-            *[p.rstrip('/') for p in ignore_any_under_paths]
         ]
```

The remaining ignore-list stays skipped — those are noise or auth-flow utilities that don't represent meaningful usage.

## Privacy verification

Signup POST bodies contain plaintext passwords. Verified [`core/services/analytics_event_emitter.py`](https://github.com/OpenConceptLab/oclapi2/blob/main/core/services/analytics_event_emitter.py) never captures request bodies — it emits only `method`, `path` (URL + query string), `headers` (with `authorization`/`cookie` redacted), `client`, `status`, and response headers. No password leak.

## Test plan

- [x] Verified emitter doesn't capture request body
- [ ] Deploy to staging, POST `/users/signup/` with a test account, confirm new row in analytics DB
- [ ] Same for `/users/logout/`
- [ ] Regression: existing tracked endpoints still record unchanged

## Cluster context

This is one of 7 PRs closing out Bundle 2 of the `data-extraction-v2` analytics instrumentation work. Each PR is small and independently mergeable except where noted.

| Repo | PR | What | Ticket |
|---|---|---|---|
| ocl-analytics-api | [#42](https://github.com/OpenConceptLab/ocl-analytics-api/pull/42) | Fix `get_client_display_name` typos | [#67](https://github.com/OpenConceptLab/ocl_online/issues/67) |
| ocl-analytics-api | [#43](https://github.com/OpenConceptLab/ocl-analytics-api/pull/43) | Add `prompt_template_key` column + migration | [#68](https://github.com/OpenConceptLab/ocl_online/issues/68) |
| ocl-analytics-api | [#44](https://github.com/OpenConceptLab/ocl-analytics-api/pull/44) | Bucket `X-OCL-CLIENT` header values + normalized `usage_by_client` | [#71](https://github.com/OpenConceptLab/ocl_online/issues/71) |
| ocl-analytics-api | [#45](https://github.com/OpenConceptLab/ocl-analytics-api/pull/45) | Split reference add/delete in `find_operation_type` | [#72](https://github.com/OpenConceptLab/ocl_online/issues/72) |
| ocl-ai-assistant | [#108](https://github.com/OpenConceptLab/ocl-ai-assistant/pull/108) | Populate `prompt_template_key` on `$invoke` | [#69](https://github.com/OpenConceptLab/ocl_online/issues/69) |
| oclapi2 | [#855](https://github.com/OpenConceptLab/oclapi2/pull/855) | Track `/users/signup/` and `/users/logout/` in analytics middleware | [#70](https://github.com/OpenConceptLab/ocl_online/issues/70) |
| oclapi2 | [#856](https://github.com/OpenConceptLab/oclapi2/pull/856) | Set `num_returned` on `$match` response (→ `item_count`) | [#73](https://github.com/OpenConceptLab/ocl_online/issues/73) |

**Merge dependencies:** independent — only touches the oclapi2 analytics middleware ignore-list.
