### PR TITLE
Set num_returned on $match response for analytics item_count

### DIFF
--- a/core/concepts/views.py
+++ b/core/concepts/views.py
@@ -989,10 +989,8 @@ class MetadataToConceptsListView(BaseAPIView):  # pragma: no cover
             )
         results = self.filter_queryset()
         response = Response(results)
-        # Surface the total matched items as num_returned so the analytics
-        # emitter records it as item_count on the APITransaction row. Plan
-        # item 11 in data-extraction-v2 wants per-request item counts on
-        # $match (sum across all input rows of matches returned).
+        # num_returned is picked up by the analytics middleware as
+        # APITransaction.item_count (see ocl_online#73).
         if isinstance(results, list):
             response['num_returned'] = sum(
                 len(r.get('results', [])) for r in results if isinstance(r, dict)

--- a/core/concepts/views.py
+++ b/core/concepts/views.py
@@ -987,7 +987,17 @@ class MetadataToConceptsListView(BaseAPIView):  # pragma: no cover
                 {'detail': 'You are currently in waitlist for $match operation.'},
                 status=status.HTTP_403_FORBIDDEN
             )
-        return Response(self.filter_queryset())
+        results = self.filter_queryset()
+        response = Response(results)
+        # Surface the total matched items as num_returned so the analytics
+        # emitter records it as item_count on the APITransaction row. Plan
+        # item 11 in data-extraction-v2 wants per-request item counts on
+        # $match (sum across all input rows of matches returned).
+        if isinstance(results, list):
+            response['num_returned'] = sum(
+                len(r.get('results', [])) for r in results if isinstance(r, dict)
+            )
+        return response
 
 
 class RerankConceptsListView(BaseAPIView):


### PR DESCRIPTION
## Summary

Sets `num_returned` on the `MetadataToConceptsListView` (`$match`) response so the analytics middleware records the total matched-item count as `APITransaction.item_count`. Before this fix, every `$match` transaction recorded `item_count=0` because the POST returned directly without going through the list mixin that normally sets the header.

Closes OpenConceptLab/ocl_online#73.

## Changes

```python
results = self.filter_queryset()
response = Response(results)
# num_returned is picked up by the analytics middleware as
# APITransaction.item_count (see ocl_online#73).
if isinstance(results, list):
    response['num_returned'] = sum(
        len(r.get('results', [])) for r in results if isinstance(r, dict)
    )
return response
```

`filter_queryset` returns a list of `{'row': ..., 'results': [...], ...}` dicts, one per input row. Summing the `results` lengths gives the total items matched across the whole request — the right denominator for "rows matched per request" analysis.

## Scope

**In**: `MetadataToConceptsListView` (`/concepts/$match/`).

**Out**: `RerankConceptsListView` (different semantics), `$match-scispacy-loinc` (lives in separate `ocl-scispacy-loinc` repo), 403 early-return path (`num_returned` stays unset → effectively 0, which is correct).

## Test plan

- [ ] Apply locally, POST `/concepts/$match/` with 5 input rows returning varying match counts
- [ ] Verify response has `num_returned` with the summed count
- [ ] Verify new APITransaction row in staging has `item_count` equal to the header value
- [ ] Regression: confirm body shape unchanged

## Cluster context

This is one of 7 PRs closing out Bundle 2 of the `data-extraction-v2` analytics instrumentation work. Each PR is small and independently mergeable except where noted.

| Repo | PR | What | Ticket |
|---|---|---|---|
| ocl-analytics-api | [#42](https://github.com/OpenConceptLab/ocl-analytics-api/pull/42) | Fix `get_client_display_name` typos | [#67](https://github.com/OpenConceptLab/ocl_online/issues/67) |
| ocl-analytics-api | [#43](https://github.com/OpenConceptLab/ocl-analytics-api/pull/43) | Add `prompt_template_key` column + migration | [#68](https://github.com/OpenConceptLab/ocl_online/issues/68) |
| ocl-analytics-api | [#44](https://github.com/OpenConceptLab/ocl-analytics-api/pull/44) | Bucket `X-OCL-CLIENT` header values + normalized `usage_by_client` | [#71](https://github.com/OpenConceptLab/ocl_online/issues/71) |
| ocl-analytics-api | [#45](https://github.com/OpenConceptLab/ocl-analytics-api/pull/45) | Split reference add/delete in `find_operation_type` | [#72](https://github.com/OpenConceptLab/ocl_online/issues/72) |
| ocl-ai-assistant | [#108](https://github.com/OpenConceptLab/ocl-ai-assistant/pull/108) | Populate `prompt_template_key` on `$invoke` | [#69](https://github.com/OpenConceptLab/ocl_online/issues/69) |
| oclapi2 | [#855](https://github.com/OpenConceptLab/oclapi2/pull/855) | Track `/users/signup/` and `/users/logout/` in analytics middleware | [#70](https://github.com/OpenConceptLab/ocl_online/issues/70) |
| oclapi2 | [#856](https://github.com/OpenConceptLab/oclapi2/pull/856) | Set `num_returned` on `$match` response (→ `item_count`) | [#73](https://github.com/OpenConceptLab/ocl_online/issues/73) |

**Merge dependencies:** independent — only touches the `$match` view.
