### PR TITLE
Improves https://github.com/OpenConceptLab/oclapi2/pull/852

### DIFF
--- a/core/common/tasks.py
+++ b/core/common/tasks.py
@@ -327,7 +327,7 @@ def bulk_import_parts_inline(self, input_list, username, update_if_exists):
     from core.importers.models import BulkImportInline
     return BulkImportInline(
         content=None, username=username, update_if_exists=update_if_exists, input_list=input_list,
-        self_task_id=self.request.id
+        self_task_id=self.request.id, skip_hierarchy_tasks=True
     ).run()
 
 

--- a/core/concepts/models.py
+++ b/core/concepts/models.py
@@ -1054,7 +1054,7 @@ class Concept(ConceptValidationMixin, SourceChildMixin, VersionedModel):  # pyli
             else:
                 update_mappings_concept.apply_async((concept.id,), queue='default', permanent=False)
 
-            if parent_concept_uris:
+            if parent_concept_uris and not data.get('_skip_hierarchy_tasks'):
                 if get(settings, 'TEST_MODE', False):
                     process_hierarchy_for_new_concept(
                         concept.id, get(initial_version, 'id'), parent_concept_uris, create_parent_version)

--- a/core/concepts/models.py
+++ b/core/concepts/models.py
@@ -990,6 +990,7 @@ class Concept(ConceptValidationMixin, SourceChildMixin, VersionedModel):  # pyli
         names = data.pop('names', []) or []
         descriptions = data.pop('descriptions', []) or []
         parent_concept_uris = data.pop('parent_concept_urls', None)
+        skip_hierarchy_tasks = data.pop('_skip_hierarchy_tasks', False)
         mappings_payload = data.pop('mappings_payload', None) or data.pop('mappings', None) or []
         mappings_result = []
         has_mapping_errors = False
@@ -1054,7 +1055,7 @@ class Concept(ConceptValidationMixin, SourceChildMixin, VersionedModel):  # pyli
             else:
                 update_mappings_concept.apply_async((concept.id,), queue='default', permanent=False)
 
-            if parent_concept_uris and not data.get('_skip_hierarchy_tasks'):
+            if parent_concept_uris and not skip_hierarchy_tasks:
                 if get(settings, 'TEST_MODE', False):
                     process_hierarchy_for_new_concept(
                         concept.id, get(initial_version, 'id'), parent_concept_uris, create_parent_version)

--- a/core/concepts/tests/tests.py
+++ b/core/concepts/tests/tests.py
@@ -168,6 +168,21 @@ class ConceptTest(OCLTestCase):
             f'/orgs/{source.organization.mnemonic}/sources/{source.mnemonic}/concepts/{concept.mnemonic}/'
         )
 
+    @patch('core.concepts.models.process_hierarchy_for_new_concept')
+    def test_persist_new_with_skip_hierarchy_tasks_flag(self, process_hierarchy_mock):
+        source = OrganizationSourceFactory(version=HEAD)
+        parent_concept = ConceptFactory(parent=source)
+        concept = Concept.persist_new({
+            **factory.build(dict, FACTORY_CLASS=ConceptFactory), 'mnemonic': 'c1', 'parent': source,
+            'names': [ConceptNameFactory.build(locale='en', name='English', locale_preferred=True)],
+            'parent_concept_urls': [parent_concept.uri],
+            '_skip_hierarchy_tasks': True,
+        })
+
+        self.assertEqual(concept.errors, {})
+        self.assertIsNotNone(concept.id)
+        process_hierarchy_mock.assert_not_called()
+
     def test_persist_new_with_autoid_sequential(self):
         source = OrganizationSourceFactory(
             version=HEAD, autoid_concept_mnemonic='sequential', autoid_concept_external_id='sequential')

--- a/core/importers/models.py
+++ b/core/importers/models.py
@@ -865,7 +865,8 @@ class BulkImportInline(BaseImporter):
                 continue
             if item_type == 'concept':
                 concept_importer = ConceptImporter(
-                    item, self.user, self.update_if_exists, skip_hierarchy_tasks=self.skip_hierarchy_tasks
+                    item, self.user, self.update_if_exists,
+                    skip_hierarchy_tasks=self.skip_hierarchy_tasks and bool(item.get('id'))
                 )
                 _result = concept_importer.delete() if action == 'delete' else concept_importer.run()
                 if self.index_resources and get(concept_importer.instance, 'id'):

--- a/core/importers/models.py
+++ b/core/importers/models.py
@@ -477,7 +477,8 @@ class ConceptImporter(BaseResourceImporter):
                 self.data['comment'] = self.data['update_comment']
                 self.data.pop('update_comment')
             self.instance = Concept.persist_new(
-                data={**self.data, '_counted': None, '_index': False}, user=self.user, create_parent_version=False)
+                data={**self.data, '_counted': None, '_index': False, '_skip_hierarchy_tasks': True},
+                user=self.user, create_parent_version=False)
             if self.instance.id:
                 return CREATED
             return self.instance.errors or errors or FAILED

--- a/core/importers/models.py
+++ b/core/importers/models.py
@@ -415,8 +415,9 @@ class ConceptImporter(BaseResourceImporter):
     def get_resource_type():
         return 'Concept'
 
-    def __init__(self, data, user, update_if_exists):
+    def __init__(self, data, user, update_if_exists, skip_hierarchy_tasks=False):
         super().__init__(data, user, update_if_exists)
+        self.skip_hierarchy_tasks = skip_hierarchy_tasks
         self.version = False
         self.instance = None
 
@@ -476,8 +477,11 @@ class ConceptImporter(BaseResourceImporter):
             if 'update_comment' in self.data:
                 self.data['comment'] = self.data['update_comment']
                 self.data.pop('update_comment')
+            persist_data = {**self.data, '_counted': None, '_index': False}
+            if self.skip_hierarchy_tasks:
+                persist_data['_skip_hierarchy_tasks'] = True
             self.instance = Concept.persist_new(
-                data={**self.data, '_counted': None, '_index': False, '_skip_hierarchy_tasks': True},
+                data=persist_data,
                 user=self.user, create_parent_version=False)
             if self.instance.id:
                 return CREATED
@@ -734,10 +738,11 @@ class ReferenceImporter(BaseResourceImporter):
 class BulkImportInline(BaseImporter):
     def __init__(  # pylint: disable=too-many-arguments
             self, content, username, update_if_exists=False, input_list=None, user=None, set_user=True,
-            self_task_id=None
+            self_task_id=None, skip_hierarchy_tasks=False
     ):
         super().__init__(content, username, update_if_exists, user, not bool(input_list), set_user)
         self.self_task_id = self_task_id
+        self.skip_hierarchy_tasks = skip_hierarchy_tasks
         self.set_task()
         if input_list:
             self.input_list = input_list
@@ -859,7 +864,9 @@ class BulkImportInline(BaseImporter):
                 )
                 continue
             if item_type == 'concept':
-                concept_importer = ConceptImporter(item, self.user, self.update_if_exists)
+                concept_importer = ConceptImporter(
+                    item, self.user, self.update_if_exists, skip_hierarchy_tasks=self.skip_hierarchy_tasks
+                )
                 _result = concept_importer.delete() if action == 'delete' else concept_importer.run()
                 if self.index_resources and get(concept_importer.instance, 'id'):
                     new_concept_ids.update(set(compact(

--- a/core/importers/models.py
+++ b/core/importers/models.py
@@ -977,6 +977,7 @@ class BulkImportParallelRunner(BaseImporter):  # pragma: no cover
         self.result = None
         self._json_result = None
         self.concept_hierarchy_map = {}  # child_uri -> [parent_uris], built before input_list is cleared
+        self.hierarchy_reconciliation_done = False
         if self.content:
             self.input_list = self.content if isinstance(self.content, list) else self.content.splitlines()
             self.total = len(self.input_list)
@@ -1119,16 +1120,27 @@ class BulkImportParallelRunner(BaseImporter):  # pragma: no cover
     def get_overall_tasks_progress(self):
         return sum(compact(self.get_sub_tasks().values_list('summary__processed', flat=True)))
 
+    def has_hierarchy_reconciliation_step(self):
+        return bool(self.concept_hierarchy_map)
+
+    def get_total_progress_target(self):
+        return self.total + int(self.has_hierarchy_reconciliation_step())
+
+    def get_completed_progress(self):
+        return self.get_overall_tasks_progress() + int(
+            self.has_hierarchy_reconciliation_step() and self.hierarchy_reconciliation_done
+        )
+
     def get_details_to_notify(self):
         summary = f"Started: {self.start_time_formatted} | " \
-            f"Processed: {self.get_overall_tasks_progress()}/{self.total} | " \
+            f"Processed: {self.get_completed_progress()}/{self.get_total_progress_target()} | " \
             f"Time: {self.elapsed_seconds}secs"
 
         return {'summary': summary}
 
     def notify_progress(self):
         if self.task:
-            self.task.summary = {'processed': self.get_overall_tasks_progress(), 'total': self.total}
+            self.task.summary = {'processed': self.get_completed_progress(), 'total': self.get_total_progress_target()}
             self.task.save()
 
     def wait_till_tasks_alive(self):
@@ -1156,6 +1168,7 @@ class BulkImportParallelRunner(BaseImporter):  # pragma: no cover
                             self.resource_wise_time[part_type] = 0
                         self.resource_wise_time[part_type] += round(time.time() - start_time, 4)
 
+        self.notify_progress()
         if self.concept_hierarchy_map:
             # P1: restrict reconciliation to concepts the importing user can actually edit,
             # mirroring the has_edit_access guard in ConceptImporter.process(). This excludes
@@ -1179,6 +1192,8 @@ class BulkImportParallelRunner(BaseImporter):  # pragma: no cover
                     inverted[parent_uri].append(child_uri)
             if inverted:
                 make_hierarchy(inverted)
+            self.hierarchy_reconciliation_done = True
+            self.notify_progress()
 
         post_import_update_resource_counts.apply_async(queue='default', permanent=False)
 

--- a/core/importers/tests.py
+++ b/core/importers/tests.py
@@ -345,6 +345,30 @@ class BulkImportInlineTest(OCLTestCase):
             sorted([concept.id, concept.get_latest_version().prev_version.id, concept.get_latest_version().id])
         )
 
+    def test_concept_import_processes_hierarchy_for_inline_import(self):
+        source = OrganizationSourceFactory(
+            organization=OrganizationFactory(mnemonic='DemoOrg'), mnemonic='DemoSource', version='HEAD'
+        )
+        parent_concept = ConceptFactory(parent=source, mnemonic='Parent')
+        data = {
+            "type": "Concept", "id": "Child", "concept_class": "Root",
+            "datatype": "None", "source": "DemoSource", "owner": "DemoOrg", "owner_type": "Organization",
+            "names": [{"name": "Child", "locale": "en", "locale_preferred": "True", "name_type": "Fully Specified"}],
+            "descriptions": [],
+            "parent_concept_urls": [parent_concept.uri],
+        }
+
+        importer = BulkImportInline(json.dumps(data), 'ocladmin', True)
+        importer.run()
+
+        self.assertEqual(importer.processed, 1)
+        self.assertEqual(len(importer.created), 1)
+        self.assertEqual(importer.failed, [])
+        child_concept = Concept.objects.filter(mnemonic='Child', id=F('versioned_object_id')).first()
+        self.assertEqual(list(child_concept.parent_concept_urls), [parent_concept.uri])
+        parent_concept.refresh_from_db()
+        self.assertEqual(list(parent_concept.child_concept_urls), [child_concept.uri])
+
     @patch('core.importers.models.batch_index_resources')
     def test_concept_import_with_extras_update(self, batch_index_resources_mock):  # pylint: disable=too-many-statements
         batch_index_resources_mock.__name__ = 'batch_index_resources'
@@ -2068,7 +2092,7 @@ class TasksTest(OCLTestCase):
         bulk_import_parts_inline([1, 2], 'username', True)  # pylint: disable=no-value-for-parameter
         bulk_import_inline_mock.assert_called_once_with(
             content=None, username='username', update_if_exists=True, input_list=[1, 2],
-            self_task_id=ANY
+            self_task_id=ANY, skip_hierarchy_tasks=True
         )
         bulk_import_inline_mock().run.assert_called_once()
 
@@ -2706,6 +2730,27 @@ class ResourceImporterTest(OCLAPITestCase):
                                            'ocladmin', 'orgs', 'OCL')
         source = Source.objects.filter(mnemonic='full_name').first()
         self.assertEqual(source.mnemonic, 'full_name')
+
+    @patch('core.importers.models.Concept.persist_new')
+    def test_import_concept_does_not_skip_hierarchy_tasks_by_default(self, persist_new_mock):
+        source = OrganizationSourceFactory(
+            organization=OrganizationFactory(mnemonic='DemoOrg'), mnemonic='DemoSource', version='HEAD'
+        )
+        parent_concept = ConceptFactory(parent=source, mnemonic='Parent')
+        persist_new_mock.return_value = Mock(id=1, errors={})
+
+        result = ResourceImporter().import_resource(
+            {
+                'type': 'concept', 'id': 'Child', 'concept_class': 'Root', 'datatype': 'None',
+                'source': 'DemoSource', 'owner': 'DemoOrg', 'owner_type': 'Organization',
+                'names': [{'name': 'Child', 'locale': 'en', 'locale_preferred': True, 'name_type': 'Fully Specified'}],
+                'descriptions': [], 'parent_concept_urls': [parent_concept.uri]
+            },
+            'ocladmin', 'orgs', 'DemoOrg'
+        )
+
+        self.assertEqual(result, 1)
+        self.assertNotIn('_skip_hierarchy_tasks', persist_new_mock.call_args.kwargs['data'])
 
 
 class ImportContentParserTest(OCLTestCase):

--- a/core/importers/tests.py
+++ b/core/importers/tests.py
@@ -1174,6 +1174,29 @@ class BulkImportParallelRunnerTest(OCLTestCase):
         task.refresh_from_db()
         self.assertEqual(task.summary, {'processed': 150, 'total': 64})
 
+    def test_notify_progress_includes_hierarchy_reconciliation_step(self):
+        task = Task(id='task-id', name='bulk_import')
+        task.save()
+        Task(id='task-1', name='sub_task', summary={'processed': 100, 'total': 200}).save()
+        Task(id='task-2', name='sub_task', summary={'processed': 50, 'total': 100}).save()
+
+        content = json.dumps({
+            "type": "Concept", "id": "ChildConcept",
+            "owner": "TestOrg", "owner_type": "Organization", "source": "TestSource",
+            "parent_concept_urls": ["/orgs/TestOrg/sources/TestSource/concepts/ParentConcept/"]
+        })
+        importer = BulkImportParallelRunner(content, 'ocladmin', True, None, 'task-id')
+        importer.tasks = [Mock(task_id='task-1'), Mock(task_id='task-2')]
+
+        importer.notify_progress()
+        task.refresh_from_db()
+        self.assertEqual(task.summary, {'processed': 150, 'total': 2})
+
+        importer.hierarchy_reconciliation_done = True
+        importer.notify_progress()
+        task.refresh_from_db()
+        self.assertEqual(task.summary, {'processed': 151, 'total': 2})
+
     def test_chunker_list(self):
         self.assertEqual(
             list(BulkImportParallelRunner.chunker_list([1, 2, 3], 3, False)), [[1], [2], [3]]
@@ -1384,6 +1407,7 @@ class BulkImportParallelRunnerTest(OCLTestCase):
         importer.run()
 
         make_hierarchy_mock.assert_called_once()
+        self.assertTrue(importer.hierarchy_reconciliation_done)
         inverted = make_hierarchy_mock.call_args[0][0]
         self.assertIn(parent.uri, inverted)
         self.assertIn(child.uri, inverted[parent.uri])

--- a/core/importers/tests.py
+++ b/core/importers/tests.py
@@ -28,7 +28,7 @@ from core.mappings.models import Mapping
 from core.mappings.tests.factories import MappingFactory
 from core.orgs.models import Organization
 from core.orgs.tests.factories import OrganizationFactory
-from core.sources.constants import AUTO_ID_UUID
+from core.sources.constants import AUTO_ID_SEQUENTIAL, AUTO_ID_UUID
 from core.sources.models import Source
 from core.sources.tests.factories import OrganizationSourceFactory
 from core.tasks.models import Task
@@ -365,6 +365,31 @@ class BulkImportInlineTest(OCLTestCase):
         self.assertEqual(len(importer.created), 1)
         self.assertEqual(importer.failed, [])
         child_concept = Concept.objects.filter(mnemonic='Child', id=F('versioned_object_id')).first()
+        self.assertEqual(list(child_concept.parent_concept_urls), [parent_concept.uri])
+        parent_concept.refresh_from_db()
+        self.assertEqual(list(parent_concept.child_concept_urls), [child_concept.uri])
+
+    def test_concept_import_processes_hierarchy_for_auto_id_when_skip_hierarchy_tasks(self):
+        source = OrganizationSourceFactory(
+            organization=OrganizationFactory(mnemonic='DemoOrg'), mnemonic='DemoSource', version='HEAD',
+            autoid_concept_mnemonic=AUTO_ID_SEQUENTIAL
+        )
+        parent_concept = ConceptFactory(parent=source, mnemonic='Parent')
+        data = {
+            "type": "Concept", "concept_class": "Root",
+            "datatype": "None", "source": "DemoSource", "owner": "DemoOrg", "owner_type": "Organization",
+            "names": [{"name": "Child", "locale": "en", "locale_preferred": "True", "name_type": "Fully Specified"}],
+            "descriptions": [],
+            "parent_concept_urls": [parent_concept.uri],
+        }
+
+        importer = BulkImportInline(json.dumps(data), 'ocladmin', True, skip_hierarchy_tasks=True)
+        importer.run()
+
+        self.assertEqual(importer.processed, 1)
+        self.assertEqual(len(importer.created), 1)
+        self.assertEqual(importer.failed, [])
+        child_concept = Concept.objects.filter(parent=source, mnemonic='1', id=F('versioned_object_id')).first()
         self.assertEqual(list(child_concept.parent_concept_urls), [parent_concept.uri])
         parent_concept.refresh_from_db()
         self.assertEqual(list(parent_concept.child_concept_urls), [child_concept.uri])


### PR DESCRIPTION
After some real-world testing, I noticed that this approach increases hierarchy processing and parallel import tasks exponentially. A better option would be to create a separate task for hierarchy processing only after concept import has finished, which would reduce the processing load.