### PR TITLE
feat(ci): add InfraScan Audit workflow

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -1,0 +1,33 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.5
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14

--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -17,7 +17,7 @@ jobs:
           chmod 777 infrascan-reports
 
       - name: Run InfraScan
-        uses: soldevelo/infrascan@v1.0.5
+        uses: soldevelo/infrascan@v1.0.6
         with:
           scanner: comprehensive
           format: html


### PR DESCRIPTION
## Summary

This PR introduces the **InfraScan Audit** GitHub Actions workflow to automate infrastructure auditing for every push and pull request.

The motivation for adding this automated scan comes from an initial manual audit performed via the [InfraScan Web Version](https://infrascan.soldevelo.com/?scan_id=8018674d-be84-4f31-b7f2-72deea02b354), which identified several critical areas for improvement:
- **Overall Grade:** F (25%)
- **Findings:** While IaC Security and Cost Optimization scored an **A (100%)**, the scan revealed **7 high-severity container vulnerabilities** across images like `postgres`, `elasticsearch`, and `keycloak`, totaling over 1000 security findings.

By integrating this workflow, we ensure that every code change is automatically audited for security risks, container vulnerabilities, and cost optimizations, helping us move toward a passing grade.

## Test Plan

- [x] Verified the `.github/workflows/infrascan.yml` syntax.
- [x] Ensured the `Upload InfraScan Report` step uses `if: always()` to provide diagnostic artifacts even if the scan identifies critical failures.

## Notes
- **Artifacts:** The generated HTML reports are stored as GitHub Action artifacts and are retained for 14 days.
- **Scanner:** The workflow uses `soldevelo/infrascan@v1.0.5` with the `comprehensive` scanner setting.
