### PR TITLE
fix(importers): sort bulk import inputs by resource type

### DIFF
--- a/core/importers/models.py
+++ b/core/importers/models.py
@@ -1014,12 +1014,25 @@ class BulkImportParallelRunner(BaseImporter):  # pragma: no cover
             self.resource_distribution[data_type].append(data)
 
     def make_parts(self):
-        _type_order = {'concept': 0, 'mapping': 1, 'reference': 2}
+        # Reflects the dependency order: containers must exist before their contents,
+        # and versioning (snapshots) must happen after all content has been imported.
+        # Organization → Source/Collection → Concept → Mapping → Reference → Versions
+        # Any unknown type falls back to 8, placing it after all known types.
+        _type_order = {
+            'organization':       0,
+            'source':             1,
+            'collection':         2,
+            'concept':            3,
+            'mapping':            4,
+            'reference':          5,
+            'source version':     6,
+            'collection version': 7,
+        }
         self.input_list = sorted(
             self.input_list,
             key=lambda item: _type_order.get(
                 (item if isinstance(item, dict) else json.loads(item)).get('type', '').lower(),
-                0
+                8
             )
         )
         prev_line = None

--- a/core/importers/models.py
+++ b/core/importers/models.py
@@ -1014,6 +1014,14 @@ class BulkImportParallelRunner(BaseImporter):  # pragma: no cover
             self.resource_distribution[data_type].append(data)
 
     def make_parts(self):
+        _type_order = {'concept': 0, 'mapping': 1, 'reference': 2}
+        self.input_list = sorted(
+            self.input_list,
+            key=lambda item: _type_order.get(
+                (item if isinstance(item, dict) else json.loads(item)).get('type', '').lower(),
+                0
+            )
+        )
         prev_line = None
         orgs = self.resource_distribution.pop('Organization', None)
         sources = self.resource_distribution.pop('Source', None)


### PR DESCRIPTION
## Problem

`BulkImportParallelRunner.make_parts()` currently groups only consecutive same-type resources into processing parts.

When a client submits an interleaved payload such as:

~~~text
Concept → Mapping → Concept → Mapping
~~~

each type transition creates a new single-item part. These tiny parts are then dispatched as independent Celery tasks and processed sequentially, effectively removing any parallelism benefits.

This behavior became evident during ICD-11 imports:

- ~37k concepts were processed efficiently in 2 parallel chunks of ~18k items each
- ~6k postcoordinated concepts interleaved with mappings degraded into ~1 item per task
- each task introduced an additional ~5s scheduling/processing gap
- resulting in an estimated ~30x slowdown for that import segment

## Solution

Introduce a stable sort of `input_list` by resource type priority at the beginning of `make_parts()` before grouping logic executes.

Proposed ordering:

~~~text
concept → mapping → reference
~~~

This guarantees that:

- all concepts become consecutive
- all mappings become consecutive
- all references become consecutive

regardless of the payload ordering provided by the client.

As a result, imports generate at most 3 large processing groups instead of potentially thousands of 1-item tasks.

## Why this is safe

The proposed change preserves current semantic behavior:

- Stable sort preserves the original relative ordering within the same resource type
  - parent concepts remain before children if originally ordered correctly
- `org/source/collection` resources are already extracted before this stage
- Mapping resolution queries concepts from the database, not from the transient input buffer
  - therefore processing all concepts before mappings remains semantically equivalent
- `DELETE` and `__action` handling inside `queue_tasks()` remains untouched
- `collect_concept_hierarchy_map()` is already type-filtered and order-independent

## Expected impact

Bulk imports containing interleaved resource types transition from:

~~~text
O(n) sequential single-item tasks
~~~

to:

~~~text
O(types) grouped parallel processing
~~~

This directly improves throughput for any client that does not pre-sort payloads before submission.