### PR TITLE
closes OpenConceptLab/ocl_issues#2527 | add input_locales ArrayField on MapProject (PR3-H backend)

### DIFF
--- a/core/map_projects/migrations/0037_mapproject_input_locales.py
+++ b/core/map_projects/migrations/0037_mapproject_input_locales.py
@@ -1,0 +1,24 @@
+# Generated for OpenConceptLab/ocl_issues#2527
+
+from django.contrib.postgres.fields import ArrayField
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('map_projects', '0036_mapproject_use_lexical_variants'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mapproject',
+            name='input_locales',
+            field=ArrayField(
+                models.CharField(max_length=10),
+                blank=True,
+                default=list,
+                null=True,
+            ),
+        ),
+    ]

--- a/core/map_projects/models.py
+++ b/core/map_projects/models.py
@@ -42,6 +42,10 @@ class MapProject(BaseModel):
     encoder_model = models.TextField(null=True, blank=True, default=settings.ENCODER_MODEL_NAME)
     prompt_template_key = models.TextField(null=True, blank=True)
     prompt_output_locale = models.CharField(max_length=10, null=True, blank=True)
+    # Plural by design — the UI currently exposes single-select, but the
+    # field is shaped for the multi-select workflow planned in a few weeks.
+    # No further migration needed at that point.
+    input_locales = ArrayField(models.CharField(max_length=10), null=True, blank=True, default=list)
     use_lexical_variants = models.BooleanField(default=False)
 
     # Fields that define how a project matches —
@@ -50,7 +54,7 @@ class MapProject(BaseModel):
     CONFIGURATION_FIELDS = [
         'algorithms', 'encoder_model', 'filters', 'include_retired',
         'lookup_config', 'score_configuration', 'target_repo_url', 'prompt_template_key',
-        'prompt_output_locale', 'use_lexical_variants'
+        'prompt_output_locale', 'input_locales', 'use_lexical_variants'
     ]
 
     class Meta:
@@ -184,6 +188,7 @@ class MapProject(BaseModel):
         cls.format_json(new_data, 'analysis')
         cls.format_json(new_data, 'algorithms')
         cls.format_json(new_data, 'lookup_config')
+        cls.format_json(new_data, 'input_locales')
 
         if parent_resource:
             new_data[parent_resource.resource_type.lower() + '_id'] = parent_resource.id

--- a/core/map_projects/serializers.py
+++ b/core/map_projects/serializers.py
@@ -23,7 +23,7 @@ class MapProjectCreateUpdateSerializer(serializers.ModelSerializer):
             'public_access', 'file', 'user_id', 'organization_id', 'description',
             'target_repo_url', 'include_retired', 'score_configuration',
             'filters', 'candidates', 'algorithms', 'lookup_config', 'analysis', 'encoder_model',
-            'prompt_template_key', 'prompt_output_locale', 'use_lexical_variants',
+            'prompt_template_key', 'prompt_output_locale', 'input_locales', 'use_lexical_variants',
         ]
 
     def validate_prompt_output_locale(self, value):
@@ -34,6 +34,19 @@ class MapProjectCreateUpdateSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 'Invalid locale. Use "auto" or a BCP-47 code like "en" or "pt-BR".'
             )
+        return value
+
+    def validate_input_locales(self, value):
+        if not value:
+            return value or []
+        import re
+        for item in value:
+            if not item:
+                continue
+            if not re.match(r'^[a-z]{2,3}(-[A-Z]{2})?$', item):
+                raise serializers.ValidationError(
+                    f'Invalid locale "{item}". Use BCP-47 codes like "en" or "pt-BR".'
+                )
         return value
 
     def prepare_object(self, validated_data, instance=None, file=None):
@@ -48,7 +61,8 @@ class MapProjectCreateUpdateSerializer(serializers.ModelSerializer):
         for attr in [
             'name', 'description', 'extras', 'target_repo_url', 'include_retired',
             'score_configuration', 'filters', 'candidates', 'algorithms', 'lookup_config', 'analysis',
-            'encoder_model', 'prompt_template_key', 'prompt_output_locale', 'use_lexical_variants',
+            'encoder_model', 'prompt_template_key', 'prompt_output_locale', 'input_locales',
+            'use_lexical_variants',
         ]:
             setattr(instance, attr, validated_data.get(attr, get(instance, attr)))
         if not instance.id:

--- a/core/map_projects/tests/tests.py
+++ b/core/map_projects/tests/tests.py
@@ -33,6 +33,10 @@ class MapProjectListViewTest(MapProjectAbstractViewTest):
                 {'label': 'category', 'hidden': False, 'dataKey': 'category', 'original': 'category'},
                 {'label': 'loinc_code', 'hidden': False, 'dataKey': 'loinc_code', 'original': 'loinc_code'}
             ]),
+            # Multipart-shaped wire format used by oclmap — input_locales is
+            # JSON-stringified so format_request_data can json.loads it back
+            # into the list that the ArrayField expects.
+            'input_locales': json.dumps(['pt-BR']),
         }
         response = self.client.post(
             '/orgs/CIEL/map-projects/',
@@ -42,6 +46,7 @@ class MapProjectListViewTest(MapProjectAbstractViewTest):
         self.assertEqual(response.status_code, 201)
         self.assertIsNotNone(response.data['id'])
         self.assertEqual(self.org.map_projects.count(), 1)
+        self.assertEqual(response.data.get('input_locales'), ['pt-BR'])
         upload_mock.assert_called_once_with(
             key=f"map_projects/{response.data['id']}/input.csv", file_content=ANY)
 
@@ -136,6 +141,7 @@ class MapProjectConfigurationsViewTest(MapProjectAbstractViewTest):
             target_repo_url='/orgs/CIEL/sources/CIEL/',
             prompt_template_key='match-recommend',
             prompt_output_locale='pt-BR',
+            input_locales=['pt-BR'],
             use_lexical_variants=True
         )
         project.save()
@@ -159,6 +165,7 @@ class MapProjectConfigurationsViewTest(MapProjectAbstractViewTest):
         self.assertEqual(response.data['target_repo_url'], '/orgs/CIEL/sources/CIEL/')
         self.assertEqual(response.data['prompt_template_key'], 'match-recommend')
         self.assertEqual(response.data['prompt_output_locale'], 'pt-BR')
+        self.assertEqual(response.data['input_locales'], ['pt-BR'])
         self.assertTrue(response.data['use_lexical_variants'])
         for field in ['analysis', 'input_file_name', 'candidates', 'matches', 'columns', 'created_by', 'updated_by']:
             self.assertNotIn(field, response.data)


### PR DESCRIPTION
## Summary

- Adds `input_locales: ArrayField(CharField(max_length=10), null=True, default=list)` to `MapProject`. Plural by design — single-select UI ships first; future multi-select needs no further migration.
- Adds `input_locales` to `MapProject.format_request_data` JSON whitelist so the JSON-stringified list from the multipart oclmap upload arrives correctly on the serializer.
- `validate_input_locales` enforces BCP-47 shape per entry.

Backend half of **PR3-H**. Frontend pairing: OpenConceptLab/oclmap (closes OpenConceptLab/ocl_issues#2526).

Master plan: ocl-online-docs/mapper/unified-mapper-model.md → PR3-H.

## Test plan

- [x] `manage.py test core.map_projects` — 6/6 pass.
- [x] `test_post` extended with `input_locales: json.dumps(['pt-BR'])` → 201 + serializer echoes `["pt-BR"]`.
- [x] `MapProjectConfigurationsViewTest.test_get_200` asserts `input_locales=['pt-BR']` round-trips through the configurations endpoint.
- [x] Migration `0037_mapproject_input_locales` applies cleanly on `--keepdb`.
- [x] pylint score steady (no new warnings).

## Out of scope

- Per-row `input_locale_column` (a column-picker in the spreadsheet schema) — deferred to a follow-on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)