### PR TITLE
Solves https://github.com/OpenConceptLab/ocl_issues/issues/2516

### DIFF
--- a/core/common/checksums.py
+++ b/core/common/checksums.py
@@ -144,10 +144,17 @@ class ChecksumDiff:
             'retired': self._get_resource_map(resources.filter(retired=True))
         }
 
+    @staticmethod
+    def _get_resource_checksums(resource):
+        """Return complete resource checksums, repairing legacy incomplete values on demand."""
+        if not resource.checksums or not resource.has_all_checksums():
+            return resource.get_checksums()
+        return resource.checksums
+
     def _get_resource_map(self, resources):
         return {
             get(resource, self.identity): {
-                'checksums': resource.checksums,
+                'checksums': self._get_resource_checksums(resource),
                 'id': resource.id
             } for resource in resources
         }

--- a/core/integration_tests/tests_sources.py
+++ b/core/integration_tests/tests_sources.py
@@ -2682,6 +2682,10 @@ class SourceVersionsChangelogViewTest(OCLAPITestCase):
         for mapping in Mapping.objects.filter(parent=source):
             mapping.set_checksums()
 
+        # Simulate legacy production data where one checksum flavor was never persisted.
+        mapping4.refresh_from_db()
+        Mapping.objects.filter(id=mapping4.id).update(checksums={'standard': mapping4.checksums['standard']})
+
         token = source.created_by.get_token()
         response = self.client.post(
             '/sources/$changelog/?inline=true',


### PR DESCRIPTION
# Context / Use Case

Improve the robustness of resource versioning and changelog generation, particularly for legacy resources containing incomplete checksum metadata.

---

# Problem

Resources migrated from older platform versions may contain partially populated `checksums` fields, such as:

- only `standard`
- missing `smart`
- incomplete hash variants

Previously, the comparison logic treated the existence of any checksum dictionary as authoritative, even when the checksum set was incomplete.

As a consequence:

- changelog generation became inconsistent
- structural changes could be missed
- version comparisons became unreliable for legacy data

Example:

A resource containing only:

~~~json
{
  "checksums": {
    "standard": "..."
  }
}
~~~

would incorrectly skip checksum regeneration because the logic assumed the checksum payload was already complete.

This resulted in inaccurate `$changelog` output and missed diffs.

---

# Solution

Implemented a repair-on-demand mechanism inside the `ChecksumDiff` utility.

The new implementation validates checksum completeness before using persisted checksum values.

---

## New Behavior

Checksum access is now guarded by:

~~~python
has_all_checksums()
~~~

If checksum data is:

- incomplete
- partially populated
- missing required hash variants

the system immediately performs an in-memory checksum recalculation before proceeding with comparison operations.

---

## Result

This guarantees that downstream version comparison and changelog logic always operate using a complete checksum set, regardless of the persistence state of legacy resources.

Benefits include:

- accurate changelog generation
- reliable structural diff detection
- backward compatibility with migrated legacy resources
- safer comparison behavior for historical source versions