### PR TITLE
Add docker-compose.local.yml for native arm64 dev builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ The new and improved OCL terminology service v2
 3. Go to http://localhost:8000/swagger/ to benefit.
 4. Go to http://localhost:8080 for keyCloak.
 
+### Dev Setup on Apple Silicon / arm64
+The published `openconceptlab/oclapi2` Docker images are amd64-only. On arm64 hosts (Apple M-series Macs, arm64 Linux) they run under Rosetta/QEMU emulation, and under load — especially Celery's post-restart indexing — the emulated cores saturate hard enough to block the API for tens of seconds. Use the local-build override to compile from the local Dockerfile instead:
+1. `sysctl -w vm.max_map_count=262144` #required by Elasticsearch (no-op on Docker Desktop / OrbStack)
+2. `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d`
+3. Go to http://localhost:8000/swagger/ to benefit.
+
+If you previously pulled the amd64 image and have it cached, force a one-time rebuild before step 2: `docker compose -f docker-compose.yml -f docker-compose.local.yml build api`.
+
 ### Configuration
 #### Authentication
 OCL API supports authentication using 2 methods. One is Django Auth (integrated into API) and the other is SSO using external service supporting OpenID such as Keycloak, Active Directory, etc.

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,23 @@
+# Opt-in override for local native builds on arm64 hosts (Apple Silicon Macs,
+# arm64 Linux). The published openconceptlab/oclapi2 images are amd64-only;
+# on arm64 they run under Rosetta/QEMU emulation, and once Celery indexing
+# kicks in the emulated cores saturate hard enough to block the API for
+# tens of seconds at a time. Building from the local Dockerfile (which uses
+# python:3.12-slim, a multi-arch base) gives a native image and ~200x faster
+# requests in practice.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+#
+# If you previously pulled the amd64 image, force a one-time rebuild:
+#   docker compose -f docker-compose.yml -f docker-compose.local.yml build api
+#
+# The api service is the only one that needs `build:` — all other services
+# that share the openconceptlab/oclapi2 image tag will reuse the locally-
+# built image once it exists.
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- New opt-in `docker-compose.local.yml` that adds `build: .` to the `api` service so arm64 dev hosts (Apple Silicon, arm64 Linux) compile the image locally from `python:3.12-slim` instead of running the amd64 published image under Rosetta/QEMU
- README section documenting when to use it
- Production / CI behavior unchanged (base `docker-compose.yml` untouched)

## Why
Closes OpenConceptLab/ocl_issues#2538. The published `openconceptlab/oclapi2:production` is amd64-only. On Apple Silicon under OrbStack / Docker Desktop, post-restart Celery indexing saturates emulated cores hard enough to block the API for 10–60s on most requests.

Measured on an M4 MacBook (24 GB):

| Operation                | amd64 emulated | arm64 native (this PR) |
|--------------------------|----------------|------------------------|
| `GET /orgs/`             | 10s timeout    | ~20 ms                 |
| `POST /concepts/`        | 60s timeout    | ~280 ms                |

Discovered while standing up a local oclapi2 + FHIRsmith demo — without this fix the stack was effectively unusable on Apple Silicon.

## Design notes
- Adds `build:` only on the `api` service; the other 8 services that share the `openconceptlab/oclapi2:${ENVIRONMENT-production}` image tag pick up the locally-tagged image automatically.
- Mirrors the existing opt-in pattern from `docker-compose.sso.yml` (invoked via `-f`) rather than re-introducing `docker-compose.override.yml` (which the repo previously took out of auto-load, now `.bak`).
- Docker compose will only build on first run — existing arm64 users with the amd64 image already cached can do a one-time `docker compose -f docker-compose.yml -f docker-compose.local.yml build api` (also called out in the README).

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.local.yml config` parses cleanly; `api` shows the merged `build:` block
- [x] First-time `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d` on M4 builds image as `arm64/linux` (verified with `docker image inspect`)
- [x] All 13 services come up healthy after native build; GET /orgs/, POST /concepts/, /fhir/metadata all serve in <300ms
- [ ] amd64 dev verifying that running with the override still does the right thing (cached image reused; no unnecessary rebuild)

## Longer-term suggestion
Publishing multi-arch images via `docker buildx --platform linux/amd64,linux/arm64` in CI would remove the need for this override entirely. Worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)