### PR TITLE
fix(storage): improve robustness of cloud storage operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ EXPORT_SERVICE=core.services.storages.cloud.minio.MinIO
 
 # MinIO / RustFS (S3-compatible) — used when EXPORT_SERVICE=MinIO
 MINIO_PORT=9090
-MINIO_ENDPOINT=rustfs:9000
+MINIO_ENDPOINT=host.docker.internal:${MINIO_PORT:-9090}
 MINIO_EXTERNAL_ENDPOINT=localhost:${MINIO_PORT:-9090}
 MINIO_ACCESS_KEY=rustfsadmin
 MINIO_SECRET_KEY=rustfsadmin

--- a/core/services/storages/cloud/aws.py
+++ b/core/services/storages/cloud/aws.py
@@ -82,7 +82,10 @@ class S3(CloudStorageServiceInterface):
         return True
 
     def has_path(self, prefix='/', delimiter='/'):
-        return len(self.__fetch_keys(prefix, delimiter)) > 0
+        try:
+            return len(self.__fetch_keys(prefix, delimiter)) > 0
+        except (ClientError, NoCredentialsError):
+            return False
 
     def get_last_key_from_path(self, prefix='/', delimiter='/'):
         keys = self.__fetch_keys(prefix, delimiter, True)

--- a/core/services/storages/cloud/minio.py
+++ b/core/services/storages/cloud/minio.py
@@ -1,5 +1,6 @@
 import base64
 import mimetypes
+from datetime import datetime
 from io import BytesIO
 
 from minio import Minio, S3Error
@@ -130,8 +131,18 @@ class MinIO(CloudStorageServiceInterface):
         """
         try:
             keys = self.__fetch_keys(prefix, delimiter)
-            key = sorted(keys, key=lambda k: k.get('LastModified'), reverse=True)[0] if len(keys) > 1 else get(keys,
-                                                                                                               '0')
+            if not keys:
+                return None
+            if len(keys) == 1:
+                return get(keys, '0.Key')
+
+            # S3-compatible stores do not always expose LastModified, so keep
+            # selection deterministic when timestamps are missing.
+            key = sorted(
+                keys,
+                key=lambda item: (item.get('LastModified') is not None, item.get('LastModified'), item.get('Key')),
+                reverse=True,
+            )[0]
             return get(key, 'Key')
         except S3Error as e:
             raise Exception(f"Could not fetch last key from path {prefix}. Error: {e}") from e  # pylint: disable=broad-exception-raised
@@ -169,7 +180,15 @@ class MinIO(CloudStorageServiceInterface):
             if delimiter and prefix.endswith(delimiter):
                 prefix = prefix[:-1]
             objects = self.client.list_objects(bucket_name=self.bucket_name, prefix=prefix, recursive=True)
-            return [{'Key': k} for k in [obj.object_name for obj in objects]]
+            return [
+                {
+                    'Key': obj.object_name,
+                    'LastModified': (
+                        obj.last_modified if isinstance(getattr(obj, 'last_modified', None), datetime) else None
+                    ),
+                }
+                for obj in objects
+            ]
         except S3Error as e:
             raise Exception(f"Could not fetch keys from bucket {self.bucket_name}. Error: {e}") from e  # pylint: disable=broad-exception-raised
 

--- a/core/services/storages/cloud/tests.py
+++ b/core/services/storages/cloud/tests.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch, mock_open, ANY, MagicMock
 
 import boto3
 from azure.storage.blob import BlobPrefix
-from botocore.exceptions import ClientError, NoCredentialsError
+from botocore.exceptions import ClientError
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.utils import timezone
@@ -45,14 +45,6 @@ class S3Test(TestCase):
         s3.upload('some/path', io.BytesIO('content'.encode()))  # pylint: disable=protected-access
 
         self.assertTrue(s3.exists('some/path'))
-
-    def test_has_path_without_credentials(self):
-        s3 = S3()
-        resource_mock = Mock()
-        resource_mock.meta = Mock(client=Mock(list_objects=Mock(side_effect=NoCredentialsError())))
-        s3._S3__resource = Mock(return_value=resource_mock)  # pylint: disable=protected-access
-
-        self.assertFalse(s3.has_path('some/path/'))
 
     def test_upload_public(self):
         conn_mock = Mock(upload_fileobj=Mock(return_value='success'))
@@ -471,38 +463,6 @@ class MinIOTest(TestCase):
         # Assert that the URL is generated in the correct format
         self.assertEqual(
             url.replace('https://', 'http://'), "http://localhost/bucket/test-file.txt")
-
-    @patch("core.services.storages.cloud.minio.Minio")
-    def test_fetch_keys(self, mock_minio_client):
-        # Mock list_objects method
-        mock_client = mock_minio_client.return_value
-        first_modified = timezone.now()
-        second_modified = first_modified + timedelta(seconds=1)
-        mock_client.list_objects = MagicMock(return_value=[
-            MagicMock(object_name="test-file1.txt", last_modified=first_modified),
-            MagicMock(object_name="test-file2.txt", last_modified=second_modified)
-        ])
-
-        client = MinIO()
-        # Call the __fetch_keys method
-        keys = client._MinIO__fetch_keys(prefix="test/", delimiter='/')  # pylint: disable=protected-access
-
-        # Assert that the correct keys were fetched
-        self.assertEqual(keys, [
-            {'Key': "test-file1.txt", 'LastModified': first_modified},
-            {'Key': "test-file2.txt", 'LastModified': second_modified},
-        ])
-        mock_client.list_objects.assert_called_once_with(bucket_name="bucket", prefix="test", recursive=True)
-
-        # Call the __fetch_keys method
-        keys = client._MinIO__fetch_keys(prefix="test/", delimiter='')  # pylint: disable=protected-access
-
-        # Assert that the correct keys were fetched
-        self.assertEqual(keys, [
-            {'Key': "test-file1.txt", 'LastModified': first_modified},
-            {'Key': "test-file2.txt", 'LastModified': second_modified},
-        ])
-        mock_client.list_objects.assert_called_with(bucket_name="bucket", prefix="test/", recursive=True)
 
     @patch("core.services.storages.cloud.minio.Minio")
     def test_get_last_key_from_path_without_last_modified(self, mock_minio_client):

--- a/core/services/storages/cloud/tests.py
+++ b/core/services/storages/cloud/tests.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch, mock_open, ANY, MagicMock
 
 import boto3
 from azure.storage.blob import BlobPrefix
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, NoCredentialsError
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.utils import timezone
@@ -45,6 +45,14 @@ class S3Test(TestCase):
         s3.upload('some/path', io.BytesIO('content'.encode()))  # pylint: disable=protected-access
 
         self.assertTrue(s3.exists('some/path'))
+
+    def test_has_path_without_credentials(self):
+        s3 = S3()
+        resource_mock = Mock()
+        resource_mock.meta = Mock(client=Mock(list_objects=Mock(side_effect=NoCredentialsError())))
+        s3._S3__resource = Mock(return_value=resource_mock)  # pylint: disable=protected-access
+
+        self.assertFalse(s3.has_path('some/path/'))
 
     def test_upload_public(self):
         conn_mock = Mock(upload_fileobj=Mock(return_value='success'))
@@ -397,6 +405,7 @@ class BlobStorageTest(TestCase):
 
 
 @patch("core.services.storages.cloud.minio.settings.MINIO_ENDPOINT", "localhost")
+@patch("core.services.storages.cloud.minio.settings.MINIO_EXTERNAL_ENDPOINT", "")
 @patch("core.services.storages.cloud.minio.settings.MINIO_ACCESS_KEY", "access_key")
 @patch("core.services.storages.cloud.minio.settings.MINIO_SECRET_KEY", "secret_key")
 @patch("core.services.storages.cloud.minio.settings.MINIO_BUCKET_NAME", "bucket")
@@ -467,9 +476,11 @@ class MinIOTest(TestCase):
     def test_fetch_keys(self, mock_minio_client):
         # Mock list_objects method
         mock_client = mock_minio_client.return_value
+        first_modified = timezone.now()
+        second_modified = first_modified + timedelta(seconds=1)
         mock_client.list_objects = MagicMock(return_value=[
-            MagicMock(object_name="test-file1.txt"),
-            MagicMock(object_name="test-file2.txt")
+            MagicMock(object_name="test-file1.txt", last_modified=first_modified),
+            MagicMock(object_name="test-file2.txt", last_modified=second_modified)
         ])
 
         client = MinIO()
@@ -477,15 +488,52 @@ class MinIOTest(TestCase):
         keys = client._MinIO__fetch_keys(prefix="test/", delimiter='/')  # pylint: disable=protected-access
 
         # Assert that the correct keys were fetched
-        self.assertEqual(keys, [{'Key': "test-file1.txt"}, {'Key': "test-file2.txt"}])
+        self.assertEqual(keys, [
+            {'Key': "test-file1.txt", 'LastModified': first_modified},
+            {'Key': "test-file2.txt", 'LastModified': second_modified},
+        ])
         mock_client.list_objects.assert_called_once_with(bucket_name="bucket", prefix="test", recursive=True)
 
         # Call the __fetch_keys method
         keys = client._MinIO__fetch_keys(prefix="test/", delimiter='')  # pylint: disable=protected-access
 
         # Assert that the correct keys were fetched
-        self.assertEqual(keys, [{'Key': "test-file1.txt"}, {'Key': "test-file2.txt"}])
+        self.assertEqual(keys, [
+            {'Key': "test-file1.txt", 'LastModified': first_modified},
+            {'Key': "test-file2.txt", 'LastModified': second_modified},
+        ])
         mock_client.list_objects.assert_called_with(bucket_name="bucket", prefix="test/", recursive=True)
+
+    @patch("core.services.storages.cloud.minio.Minio")
+    def test_get_last_key_from_path_without_last_modified(self, mock_minio_client):
+        # Mock list_objects method with objects that do not expose last_modified.
+        mock_client = mock_minio_client.return_value
+        mock_client.list_objects = MagicMock(return_value=[
+            Mock(object_name="foo/bar/foobar.json"),
+            Mock(object_name="foo/bar/foobar1.json"),
+        ])
+
+        client = MinIO()
+
+        # The method should remain stable even when MinIO does not return timestamps.
+        key = client.get_last_key_from_path("foo/bar/")
+
+        self.assertEqual(key, "foo/bar/foobar1.json")
+        mock_client.list_objects.assert_called_once_with(bucket_name="bucket", prefix="foo/bar", recursive=True)
+
+    @patch("core.services.storages.cloud.minio.Minio")
+    def test_get_last_key_from_path_uses_last_modified(self, mock_minio_client):
+        older = timezone.now()
+        newer = older + timedelta(seconds=1)
+        mock_client = mock_minio_client.return_value
+        mock_client.list_objects = MagicMock(return_value=[
+            Mock(object_name="foo/bar/z-old.json", last_modified=older),
+            Mock(object_name="foo/bar/a-new.json", last_modified=newer),
+        ])
+
+        client = MinIO()
+
+        self.assertEqual(client.get_last_key_from_path("foo/bar/"), "foo/bar/a-new.json")
 
     @patch("core.services.storages.cloud.minio.Minio")
     def test_delete_objects(self, mock_minio_client):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,11 +56,14 @@ services:
       - AZURE_STORAGE_CONTAINER_NAME
       - AZURE_STORAGE_CONNECTION_STRING
       - FHIR_VALIDATOR_URL=${FHIR_VALIDATOR_URL-http://fhir_validator:3500}
-      - MINIO_ACCESS_KEY
-      - MINIO_BUCKET_NAME
-      - MINIO_ENDPOINT
-      - MINIO_SECRET_KEY
-      - MINIO_SECURE
+      # Export storage defaults to host-published local RustFS/MinIO-compatible storage.
+      - EXPORT_SERVICE=${EXPORT_SERVICE-core.services.storages.cloud.minio.MinIO}
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT-host.docker.internal:${MINIO_PORT:-9090}}
+      - MINIO_EXTERNAL_ENDPOINT=${MINIO_EXTERNAL_ENDPOINT-localhost:${MINIO_PORT:-9090}}
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY-rustfsadmin}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY-rustfsadmin}
+      - MINIO_BUCKET_NAME=${MINIO_BUCKET_NAME-oclapi2-dev}
+      - MINIO_SECURE=${MINIO_SECURE-FALSE}
       - ENABLE_THROTTLING
       - SERVICE_NAME=${SERVICE_NAME-oclapi2}
       - NO_LM=${NO_LM-FALSE}
@@ -98,6 +101,14 @@ services:
       - AWS_SECRET_ACCESS_KEY
       - AWS_STORAGE_BUCKET_NAME
       - AWS_REGION_NAME
+      # The default queue runs export tasks, so it needs the same storage config as the API.
+      - EXPORT_SERVICE=${EXPORT_SERVICE-core.services.storages.cloud.minio.MinIO}
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT-host.docker.internal:${MINIO_PORT:-9090}}
+      - MINIO_EXTERNAL_ENDPOINT=${MINIO_EXTERNAL_ENDPOINT-localhost:${MINIO_PORT:-9090}}
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY-rustfsadmin}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY-rustfsadmin}
+      - MINIO_BUCKET_NAME=${MINIO_BUCKET_NAME-oclapi2-dev}
+      - MINIO_SECURE=${MINIO_SECURE-FALSE}
       - NO_LM=${NO_LM-TRUE}
     volumes:
       - upload-data:/code/uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,14 +56,6 @@ services:
       - AZURE_STORAGE_CONTAINER_NAME
       - AZURE_STORAGE_CONNECTION_STRING
       - FHIR_VALIDATOR_URL=${FHIR_VALIDATOR_URL-http://fhir_validator:3500}
-      # Export storage defaults to host-published local RustFS/MinIO-compatible storage.
-      - EXPORT_SERVICE=${EXPORT_SERVICE-core.services.storages.cloud.minio.MinIO}
-      - MINIO_ENDPOINT=${MINIO_ENDPOINT-host.docker.internal:${MINIO_PORT:-9090}}
-      - MINIO_EXTERNAL_ENDPOINT=${MINIO_EXTERNAL_ENDPOINT-localhost:${MINIO_PORT:-9090}}
-      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY-rustfsadmin}
-      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY-rustfsadmin}
-      - MINIO_BUCKET_NAME=${MINIO_BUCKET_NAME-oclapi2-dev}
-      - MINIO_SECURE=${MINIO_SECURE-FALSE}
       - ENABLE_THROTTLING
       - SERVICE_NAME=${SERVICE_NAME-oclapi2}
       - NO_LM=${NO_LM-FALSE}
@@ -101,14 +93,6 @@ services:
       - AWS_SECRET_ACCESS_KEY
       - AWS_STORAGE_BUCKET_NAME
       - AWS_REGION_NAME
-      # The default queue runs export tasks, so it needs the same storage config as the API.
-      - EXPORT_SERVICE=${EXPORT_SERVICE-core.services.storages.cloud.minio.MinIO}
-      - MINIO_ENDPOINT=${MINIO_ENDPOINT-host.docker.internal:${MINIO_PORT:-9090}}
-      - MINIO_EXTERNAL_ENDPOINT=${MINIO_EXTERNAL_ENDPOINT-localhost:${MINIO_PORT:-9090}}
-      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY-rustfsadmin}
-      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY-rustfsadmin}
-      - MINIO_BUCKET_NAME=${MINIO_BUCKET_NAME-oclapi2-dev}
-      - MINIO_SECURE=${MINIO_SECURE-FALSE}
       - NO_LM=${NO_LM-TRUE}
     volumes:
       - upload-data:/code/uploads


### PR DESCRIPTION
I did it so rustfs and oclweb2 can run seamless with export tests locally @snyaggarwal 

* Make key fetching deterministic for S3-compatible stores by improving sorting logic and handling objects that lack standard metadata

* Add robust error handling to AWS S3 lookups to gracefully handle missing credentials or failed API calls

* Update development configuration defaults for consistent use of local MinIO/RustFS endpoint settings