### PR TITLE
feat(search): support boolean property filters and facets

### DIFF
--- a/core/common/views.py
+++ b/core/common/views.py
@@ -316,6 +316,24 @@ class BaseAPIView(generics.GenericAPIView, PathWalkerMixin):
             match_word_fields_map,
         ), fields
 
+    def get_declared_property_types(self):
+        return get(self, 'parent_resource.property_types') or {}
+
+    @staticmethod
+    def get_boolean_property_criterion(property_code, *values):
+        """
+        A boolean-declared property reaches Elasticsearch as boolean, long or text, depending on
+        what the concepts actually store in extras -- `false` may be indexed as `false` or as `0`.
+        Lenient match clauses let the literals that do not fit the field's type be skipped instead
+        of failing the whole query with a 400. See OpenConceptLab/ocl_issues#2692.
+        """
+        field = f"properties.{property_code}"
+        return Q(
+            'bool',
+            should=[Q('match', **{field: {'query': value, 'lenient': True}}) for value in values],
+            minimum_should_match=1
+        )
+
     def get_faceted_criterion(self, split=False, params=None, **kwargs):
         filters = self.get_faceted_filters(
             split=split,
@@ -342,7 +360,15 @@ class BaseAPIView(generics.GenericAPIView, PathWalkerMixin):
                 if not val:
                     new_attr = "properties." + property_code
                     return ~Q("exists", field=new_attr)
-                return Q('term', **{f"properties.{property_code}.keyword": val.strip('\"').strip('\'')})
+
+                clean_val = val.strip('\"').strip('\'')
+                if self.get_declared_property_types().get(property_code) == 'boolean':
+                    if clean_val in get_truthy_values():
+                        return self.get_boolean_property_criterion(property_code, 'true', '1')
+                    if clean_val in get_falsy_values():
+                        return self.get_boolean_property_criterion(property_code, 'false', '0')
+
+                return Q('term', **{f"properties.{property_code}.keyword": clean_val})
 
             return Q('term', **{attr: val.strip('\"').strip('\'')})
 

--- a/core/concepts/search.py
+++ b/core/concepts/search.py
@@ -8,6 +8,21 @@ from core.common.utils import get_embeddings, is_canonical_uri
 from core.concepts.models import Concept
 
 
+class BooleanTermsFacet(TermsFacet):
+    """
+    Terms facet for a property the source declares as boolean. Such a property is mapped as
+    boolean or as long, depending on whether the concepts store `false` or `0` in extras: a
+    boolean field carries the readable form in key_as_string, which the default get_value
+    discards, and a long field only ever yields 0/1. Both are surfaced as 'false'/'true', the
+    values the filter accepts back. See OpenConceptLab/ocl_issues#2692.
+    """
+    BUCKET_KEYS = {0: 'false', 1: 'true'}
+
+    def get_value(self, bucket):
+        key = bucket['key']
+        return get(bucket, 'key_as_string') or self.BUCKET_KEYS.get(key, key)
+
+
 class ConceptFacetedSearch(CustomESFacetedSearch):
     index = 'concepts'
     doc_types = [Concept]
@@ -53,11 +68,15 @@ class ConceptFacetedSearch(CustomESFacetedSearch):
 
     @staticmethod
     def build_property_facets_from_source(parent):
-        return {
-            f"properties__{_filter['code']}": TermsFacet(field=f"properties.{_filter['code']}.keyword", size=FACET_SIZE)
-            for _filter in (get(parent, 'filters') or [])
-        }
-
+        property_types = get(parent, 'property_types') or {}
+        facets = {}
+        for _filter in (get(parent, 'filters') or []):
+            code = _filter['code']
+            if property_types.get(code) == 'boolean':
+                facets[f"properties__{code}"] = BooleanTermsFacet(field=f"properties.{code}", size=FACET_SIZE)
+            else:
+                facets[f"properties__{code}"] = TermsFacet(field=f"properties.{code}.keyword", size=FACET_SIZE)
+        return facets
 
 
 class ConceptFuzzySearch:  # pragma: no cover

--- a/core/integration_tests/tests_concepts.py
+++ b/core/integration_tests/tests_concepts.py
@@ -3053,6 +3053,117 @@ class ConceptListViewTest(OCLAPITestCase):
         self.assertEqual([x for x in response.data['facets']['fields']['conceptClass'] if x[0] == 'classA'], [])
 
 
+class ConceptPropertyFilterViewTest(OCLAPITestCase):
+    """
+    Property filtering must follow the type declared on the source. A property declared boolean
+    reaches Elasticsearch as `boolean` when extras hold `false` and as `long` when they hold `0`,
+    and neither has a `.keyword` sub-field -- see OpenConceptLab/ocl_issues#2692.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.patch_concept_es_mapping_for_ci()
+        self.source = OrganizationSourceFactory(mnemonic='PropSource')
+        self.source.properties = [
+            {'code': 'pt_bool', 'type': 'boolean'},
+            {'code': 'pt_intbool', 'type': 'boolean'},
+            {'code': 'pt_str', 'type': 'string'},
+        ]
+        self.source.filters = [
+            {'code': 'pt_bool', 'operator': '='},
+            {'code': 'pt_intbool', 'operator': '='},
+            {'code': 'pt_str', 'operator': '='},
+        ]
+        self.source.save()
+
+        self.false_concept = ConceptFactory(mnemonic='BoolFalse', parent=self.source, extras={'pt_bool': False})
+        self.true_concept = ConceptFactory(mnemonic='BoolTrue', parent=self.source, extras={'pt_bool': True})
+        self.zero_concept = ConceptFactory(mnemonic='IntZero', parent=self.source, extras={'pt_intbool': 0})
+        self.one_concept = ConceptFactory(mnemonic='IntOne', parent=self.source, extras={'pt_intbool': 1})
+        self.str_concept = ConceptFactory(mnemonic='StrFalse', parent=self.source, extras={'pt_str': 'false'})
+        self.bare_concept = ConceptFactory(mnemonic='NoProperty', parent=self.source, extras={})
+        for concept in (
+                self.false_concept, self.true_concept, self.zero_concept,
+                self.one_concept, self.str_concept, self.bare_concept
+        ):
+            self.source.concepts.add(concept.get_latest_version())
+        ConceptDocument().update(self.source.concepts_set.all())
+
+    def get_ids(self, query):
+        response = self.client.get(self.source.concepts_url + query)
+        self.assertEqual(response.status_code, 200)
+        return sorted(data['id'] for data in response.data)
+
+    def test_boolean_property_value_match(self):
+        self.assertEqual(self.get_ids('?properties__pt_bool=false'), ['BoolFalse'])
+        self.assertEqual(self.get_ids('?properties__pt_bool=0'), ['BoolFalse'])
+        self.assertEqual(self.get_ids('?properties__pt_bool=true'), ['BoolTrue'])
+        self.assertEqual(self.get_ids('?properties__pt_bool=1'), ['BoolTrue'])
+
+    def test_boolean_property_negation_includes_concepts_without_the_attribute(self):
+        self.assertEqual(
+            self.get_ids('?properties__pt_bool=!false'),
+            ['BoolTrue', 'IntOne', 'IntZero', 'NoProperty', 'StrFalse']
+        )
+
+    def test_boolean_property_empty_value_returns_concepts_without_the_attribute(self):
+        self.assertEqual(
+            self.get_ids('?properties__pt_bool='), ['IntOne', 'IntZero', 'NoProperty', 'StrFalse']
+        )
+
+    def test_boolean_property_unparseable_value_does_not_error(self):
+        self.assertEqual(self.get_ids('?properties__pt_bool=abc'), [])
+
+    def test_boolean_property_facet_buckets(self):
+        response = self.client.get(self.source.concepts_url + '?facetsOnly=true')
+
+        self.assertEqual(response.status_code, 200)
+        buckets = sorted(response.data['facets']['fields']['properties__pt_bool'], key=lambda bucket: bucket[0])
+        self.assertEqual([bucket[0] for bucket in buckets], ['false', 'true'])
+        self.assertTrue(all(bucket[1] >= 1 for bucket in buckets))
+
+    def test_integer_valued_boolean_property_value_match(self):
+        self.assertEqual(self.get_ids('?properties__pt_intbool=false'), ['IntZero'])
+        self.assertEqual(self.get_ids('?properties__pt_intbool=0'), ['IntZero'])
+        self.assertEqual(self.get_ids('?properties__pt_intbool=true'), ['IntOne'])
+        self.assertEqual(self.get_ids('?properties__pt_intbool=1'), ['IntOne'])
+
+    def test_integer_valued_boolean_property_negation(self):
+        self.assertEqual(
+            self.get_ids('?properties__pt_intbool=!false'),
+            ['BoolFalse', 'BoolTrue', 'IntOne', 'NoProperty', 'StrFalse']
+        )
+
+    def test_integer_valued_boolean_property_does_not_error(self):
+        """The declared type says boolean but the field is mapped long -- must degrade, not 400."""
+        response = self.client.get(self.source.concepts_url + '?properties__pt_intbool=abc')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+
+    def test_integer_valued_boolean_property_facet_buckets(self):
+        response = self.client.get(self.source.concepts_url + '?facetsOnly=true')
+
+        self.assertEqual(response.status_code, 200)
+        buckets = sorted(response.data['facets']['fields']['properties__pt_intbool'], key=lambda bucket: bucket[0])
+        self.assertEqual([bucket[0] for bucket in buckets], ['false', 'true'])
+        self.assertTrue(all(bucket[1] >= 1 for bucket in buckets))
+
+    def test_string_property_is_unchanged(self):
+        self.assertEqual(self.get_ids('?properties__pt_str=false'), ['StrFalse'])
+        self.assertEqual(
+            self.get_ids('?properties__pt_str=!false'),
+            ['BoolFalse', 'BoolTrue', 'IntOne', 'IntZero', 'NoProperty']
+        )
+
+        response = self.client.get(self.source.concepts_url + '?facetsOnly=true')
+
+        self.assertEqual(response.status_code, 200)
+        buckets = response.data['facets']['fields']['properties__pt_str']
+        self.assertEqual([bucket[0] for bucket in buckets], ['false'])
+        self.assertTrue(buckets[0][1] >= 1)
+
+
 class ConceptNameRetrieveUpdateDestroyViewTest(OCLAPITestCase):
     def setUp(self):
         super().setUp()

--- a/core/sources/models.py
+++ b/core/sources/models.py
@@ -282,6 +282,12 @@ class Source(DirtyFieldsMixin, ConceptContainerModel):
         return get(self.meta, 'display.concept_summary_properties') or []
 
     @property
+    def property_types(self):
+        return {
+            prop['code']: prop.get('type') for prop in (self.properties or []) if prop.get('code')
+        }
+
+    @property
     def concept_filter_order(self):
         return get(self.meta, 'display.concept_filter_order') or []
 

--- a/core/sources/tests/tests.py
+++ b/core/sources/tests/tests.py
@@ -1382,6 +1382,19 @@ class SourceCloneAPITest(OCLAPITestCase):
 
 
 class SourceValidationTest(OCLTestCase):
+    def test_property_types(self):
+        self.assertEqual(Source().property_types, {})
+        self.assertEqual(Source(properties=[]).property_types, {})
+        self.assertEqual(
+            Source(properties=[
+                {'code': 'is_clinical', 'type': 'boolean'},
+                {'code': 'height', 'type': 'integer'},
+                {'code': 'label'},
+                {'type': 'string'},
+            ]).property_types,
+            {'is_clinical': 'boolean', 'height': 'integer', 'label': None}
+        )
+
     def test_clean_properties_valid(self):
         source = Source(properties=[
             {'code': 'height', 'type': 'integer'},


### PR DESCRIPTION
Solves https://github.com/OpenConceptLab/ocl_issues/issues/2697

Evidence: https://github.com/OpenConceptLab/ocl_issues/issues/2697#issuecomment-5374028251

* Allows filtering based on boolean properties regardless of how they are stored (e.g., strings or numeric values)

* Introduces a dedicated facet type for boolean fields to correctly display state in search results